### PR TITLE
Fix compile error for lastpass x86 BOF

### DIFF
--- a/src/Remote/lastpass/entry.c
+++ b/src/Remote/lastpass/entry.c
@@ -116,7 +116,7 @@ END:
 void Write_Memory_Range( HANDLE hProcess, LPCVOID address, size_t address_sz, unsigned int pid)
 {
     BOOL rc = FALSE;
-    size_t bytesRead = 0;
+    SIZE_T bytesRead = 0;
     char *buffer = {0};
     int index = 0;
     int ret_sz = 1;


### PR DESCRIPTION
This PR fixes a build issue with the lastpass x86 BOF due to a type mismatch.

[`ReadProcessMemory`](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-readprocessmemory) expects a Windows `SIZE_T*` type for the `lpNumberOfBytesRead` out param.

The Windows [`SIZE_T`](https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types#size_t) type is not at all the same as a C standard [`size_t`](https://en.cppreference.com/w/c/types/size_t) type which is where this issue comes from.

```
matt@laptop :: ~/Documents/dev/bofs/CS-Remote-OPs-BOF/src/Remote/lastpass (git)-[main] 2 >> make
x86_64-w64-mingw32-gcc -o lastpass.x64.o -I ../../common -Os -c entry.c -DBOF
i686-w64-mingw32-gcc -o lastpass.x86.o -I ../../common -Os -c entry.c -DBOF
entry.c: In function 'Write_Memory_Range':
entry.c:126:77: error: passing argument 5 of 'KERNEL32$ReadProcessMemory' from incompatible pointer type [-Wincompatible-pointer-types]
  126 |     rc = KERNEL32$ReadProcessMemory( hProcess, address, buffer, address_sz, &bytesRead );
      |                                                                             ^~~~~~~~~~
      |                                                                             |
      |                                                                             size_t * {aka unsigned int *}
In file included from entry.c:3:
../../common/bofdefs.h:69:134: note: expected 'SIZE_T *' {aka 'long unsigned int *'} but argument is of type 'size_t *' {aka 'unsigned int *'}
   69 | WINBASEAPI WINBOOL WINAPI KERNEL32$ReadProcessMemory (HANDLE hProcess, LPCVOID lpBaseAddress, LPVOID lpBuffer, SIZE_T nSize, SIZE_T *lpNumberOfBytesRead);
      |                                                                                                                              ~~~~~~~~^~~~~~~~~~~~~~~~~~~
make: *** [Makefile:10: all] Error 1
matt@laptop :: ~/Documents/dev/bofs/CS-Remote-OPs-BOF/src/Remote/lastpass (git)-[main] 2 >>
```

This change should fix the lastpass compile issue for x86.