### PR TITLE
Update command usage format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,41 +16,41 @@ You are welcome to use these, but issues opened related to these will be closed 
 
 |Command|Usage|Notes|
 |-------|-----|-----|
-|adcs_request| adcs_request CA [opt:TEMPLATE] [opt:SUBJECT] [opt: ALTNAME] [opt: INSTALL] [opt:MACHINE] | Request an enrollment certificate|
+|adcs_request| adcs_request [CA] [OPT:TEMPLATE] [OPT:SUBJECT] [OPT:ALTNAME] [OPT:INSTALL] [OPT:MACHINE] [OPT:ADD_APP_POLICY] [OPT:DNS] | Request an enrollment certificate|
 |adcs_request_on_behalf| adcs_request_on_behalf [TEMPLATE] [REQUESTER] [ENROLLMENT_AGENT.pfx] [Download_Name] | Request an enrollment certificate on behalf of another user|
-|adduser| adduser <USERNAME> <PASSWORD> <SERVER> | Add specified user to a machine|
-|addusertogroup| addusertogroup <USERNAME> <GROUPNAME> <SERVER> <DOMAIN> | Add specified user to a group|
+|adduser| adduser [USERNAME] [PASSWORD] [SERVER] | Add specified user to a machine|
+|addusertogroup| addusertogroup [USERNAME] [GROUPNAME] [SERVER] [DOMAIN] | Add specified user to a group|
 |chromeKey| chromeKey | Decrypt the provided base64 encoded Chrome key|
-|enableuser| enableuser <USERNAME> <DOMAIN> | Enable and unlock the specified user account|
-|get_azure_token| get_azure_token <client-id> <scope> <browser (see below)> [opt: hint] [opt: browser_path] | Attempts to complete an OAuth codeflow grant against azure using saved logins |
-|get_priv| get_priv <Privledge Name> | Activate the specified token privledge, more for non-cobalt strike users|
+|enableuser| enableuser [USERNAME] [DOMAIN] | Enable and unlock the specified user account|
+|get_azure_token| get_azure_token [CLIENT ID] [SCOPE] [BROWSER] [OPT:HINT] [OPT:BROWSER PATH] | Attempts to complete an OAuth codeflow grant against azure using saved logins |
+|get_priv| get_priv [Privledge Name] | Activate the specified token privledge, more for non-cobalt strike users|
 |global_unprotect| global_unprotect | Locates and Decrypts GlobalProtect config files converted from: [GlobalUnProtect](https://github.com/rotarydrone/GlobalUnProtect/tree/409d64b097e0a928a5545051e40e1566e9c26bd0)|
-|lastpass | lastpass <number of pids> <pid>,<pid>,<pid> ... | Search Chrome, brave memory for LastPass passwords and data|
-|make_token_cert| make_token_cert <path to .pfx> [opt: password] | Impersonates a user using the altname of a .pfx file |
-|office_tokens| office_tokens <pid> | Collect Office JWT Tokens from any Office process|
-|procdump| procdump <PID> <FILEOUT> | Dump the specified process to the specified output file|
-|ProcessDestroy| ProcessDestroy <PID> <OPT:HANDLEID> | Close handle(s) in a process|
-|ProcessListHandles| ProcessListHandles <PID> | List all open handles in a specified process|
-|reg_delete| reg_delete <OPT:HOSTNAME> <HIVE> <REGPATH> <OPT:REGVALUE> | Delete a registry key|
-|reg_save| reg_save <HIVE> <REGPATH> <FILEOUT> | Save a registry hive to disk|
-|reg_set| reg_set <OPT:HOSTNAME> <HIVE> <KEY> <VALUE> <TYPE> <DATA> | Set / create a registry key|
-|sc_config| sc_config <SVCNAME> <BINPATH> <ERRORMODE> <STARTMODE> <OPT:HOSTNAME> | Configure an existing service|
-|sc_create| sc_create <SVCNAME> <DISPLAYNAME> <BINPATH> <DESCRIPTION> <ERRORMODE> <STARTMODE> <OPT:TYPE> <OPT:HOSTNAME> | Create a new service|
-|sc_delete| sc_delete <SVCNAME> <OPT:HOSTNAME> | Delete an existing service|
-|sc_failure| sc_failure <SVCNAME> <RESETPERIOD> <REBOOTMESSAGE> <COMMAND> <NUMACTIONS> <ACTIONS> <OPT:HOSTNAME> | Configures the actions upon failure of an existing service|
-|sc_description| sc_description <SVCNAME> <DESCRIPTION> <OPT:HOSTNAME> | Modify an existing services description|
-|sc_start| sc_start <SVCNAME> <OPT:HOSTNAME> | Start an existing service|
-|sc_stop| sc_stop <SVCNAME> <OPT:HOSTNAME> | Stop an existing service|
-|schtaskscreate| schtaskscreate <OPT:HOSTNAME> <USERNAME> <PASSWORD> <TASKPATH> <USERMODE> <FORCEMODE> | Create a new scheduled task (via xml definition)|
-|schtasksdelete| schtasksdelete <OPT:HOSTNAME> <TASKNAME> <TYPE> | Delete an existing scheduled task|
-|schtasksrun| schtasksrun <OPT:HOSTNAME> <TASKNAME> | Start a scheduled task|
-|schtasksstop| schtasksstop <OPT:HOSTNAME> <TASKNAME> | Stop a running scheduled task|
-|setuserpass| setuserpass <USERNAME> <PASSWORD> <DOMAIN> | Set a user's password|
-|shspawnas| shspawnas <domain> <username> <password> <opt: shellcodefile> | A misguided attempt at injecting code into a newly spawned process|
-|shutdown| shutdown <hostname> "<message>" <time> <closeapps> <reboot> | Shutdown or reboot a local or remote computer, with or without a warning/message
-|slack_cookie| slack_cookie <pid> | Collect the Slack authentication cookie from a Slack process|
-|unexpireuser| unexpireuser <USERNAME> <DOMAIN> | Set a user account to never expire|
-|ghost_task| ghost_task <hostname/localhost> <operation> <taskname> <program> <argument> <username> <scheduletype> <time/second> <day> | Add/Delete a ghost task. |
+|lastpass | lastpass [NUMBER OF PIDs] [PID],[PID],[PID],[PID] ... | Search Chrome, brave memory for LastPass passwords and data|
+|make_token_cert| make_token_cert [.PFX LOCAL PATH] [OPT:PFX PASSWORD]| Impersonates a user using the altname of a .pfx file |
+|office_tokens| office_tokens [PID] | Collect Office JWT Tokens from any Office process|
+|procdump| procdump [PID] [FILEOUT] | Dump the specified process to the specified output file|
+|ProcessDestroy| ProcessDestroy [PID] [OPT:HANDLEID] | Close handle(s) in a process|
+|ProcessListHandles| ProcessListHandles [PID] | List all open handles in a specified process|
+|reg_delete| reg_delete [OPT:HOSTNAME] [HIVE] [REGPATH] [OPT:REGVALUE] | Delete a registry key|
+|reg_save| reg_save [HIVE] [REGPATH] [FILEOUT] | Save a registry hive to disk|
+|reg_set| reg_set [OPT:HOSTNAME] [HIVE] [KEY] [VALUE] [TYPE] [DATA] | Set / create a registry key|
+|sc_config| sc_config [SVCNAME] [BINPATH] [ERRORMODE] [STARTMODE] [OPT:HOSTNAME] | Configure an existing service|
+|sc_create| sc_create [SVCNAME] [DISPLAYNAME] [BINPATH] [DESCRIPTION] [ERRORMODE] [STARTMODE] [OPT:TYPE] [OPT:HOSTNAME] | Create a new service|
+|sc_delete| sc_delete [SVCNAME] [OPT:HOSTNAME] | Delete an existing service|
+|sc_failure| sc_failure [SVCNAME] [RESETPERIOD] [REBOOTMESSAGE] [COMMAND] [NUMACTIONS] [ACTIONS] [OPT:HOSTNAME] | Configures the actions upon failure of an existing service|
+|sc_description| sc_description [SVCNAME] [DESCRIPTION] [OPT:HOSTNAME] | Modify an existing services description|
+|sc_start| sc_start [SVCNAME] [OPT:HOSTNAME] | Start an existing service|
+|sc_stop| sc_stop [SVCNAME] [OPT:HOSTNAME] | Stop an existing service|
+|schtaskscreate| schtaskscreate [OPT:HOSTNAME] [USERNAME] [PASSWORD] [TASKPATH] [USERMODE] [FORCEMODE] | Create a new scheduled task (via xml definition)|
+|schtasksdelete| schtasksdelete [OPT:HOSTNAME] [TASKNAME] [TYPE] | Delete an existing scheduled task|
+|schtasksrun| schtasksrun [OPT:HOSTNAME] [TASKNAME] | Start a scheduled task|
+|schtasksstop| schtasksstop [OPT:HOSTNAME] [TASKNAME] | Stop a running scheduled task|
+|setuserpass| setuserpass [USERNAME] [PASSWORD] [DOMAIN] | Set a user's password|
+|shspawnas| shspawnas [DOMAIN] [USERNAME] [PASSWORD] [OPT:SHELLCODEFILE] | A misguided attempt at injecting code into a newly spawned process|
+|shutdown| shutdown [HOSTNAME] \"[MESSAGE]\" [TIME] [CLOSEAPPS] [REBOOT] | Shutdown or reboot a local or remote computer, with or without a warning/message
+|slack_cookie| slack_cookie [PID] | Collect the Slack authentication cookie from a Slack process|
+|unexpireuser| unexpireuser [USERNAME] [DOMAIN] | Set a user account to never expire|
+|ghost_task| ghost_task [HOSTNAME/LOCALHOST] [OPERATION] [TASKANME] [PROGRAM] [ARGUMENT] [USERNAME] [SCHEDULETYPE] [TIME/SECOND] [DAY] | Add/Delete a ghost task. |
 
 ## Contributing
 


### PR DESCRIPTION
During a repository review, I noticed that the previous commit introduced an issue with the README’s markdown table. The use of < and > was breaking the formatting. Since the usage format was also updated in the previous PR to match the SA repository, I decided to fix the markdown accordingly and ensure everything displays correctly.

Thanks for your time!