### PR TITLE
make_token_cert: Fix handle cleanup and NULL check

### DIFF
--- a/src/Remote/make_token_cert/entry.c
+++ b/src/Remote/make_token_cert/entry.c
@@ -114,6 +114,13 @@ VOID go(
 	{
 		return;
 	}
+
+	if(!cert || len == 0)
+	{
+		internal_printf("Cert data is empty\n");
+		goto go_end;
+	}
+
 	internal_printf("Loading Cert into temp store\n");
 	PCCERT_CONTEXT pcert = NULL;
 	HCERTSTORE store = LoadCert(cert, password, len, passlen, &pcert);

--- a/src/Remote/make_token_cert/entry.c
+++ b/src/Remote/make_token_cert/entry.c
@@ -91,6 +91,11 @@ void ImpersonateUser(PCCERT_CONTEXT pCertContext)
 	#endif
 	BeaconPrintf(CALLBACK_OUTPUT, "success");
 
+end:
+	if(hToken)
+	{
+		ADVAPI32$CloseHandle(hToken);
+	}
 }
 
 #ifdef BOF


### PR DESCRIPTION
Disclosure: I used AI to identify and help me fix this bug. I understand what the code does and have confirmed the fix is correct and compiles.

797cca1627ebf3fc69785e3feb79a9c076accbfc The handle for hToken wasn't closed. Fixed by closing it at end.

d9848db5b4051ce93103e3d64db3eb7f3a8e95b9 The certificate blob from `BeaconDataExtract` is passed to `LoadCert` without checking for NULL or zero length. This may lead to a NULL cert pointer being set as `pfxData.pbData`, which likely crashes when passed to `PFXImportCertStore`. I didn't test if it does. Fixed by validating `cert` and `len` before passing.