### PR TITLE
reg_set: Fix bug in cleanup/free

### DIFF
--- a/src/Remote/reg_set/entry.c
+++ b/src/Remote/reg_set/entry.c
@@ -56,7 +56,7 @@ set_regkey_end:
 	if(RemoteKey)
 	{
 		ADVAPI32$RegCloseKey(RemoteKey);
-		rootkey = NULL;
+		RemoteKey = NULL;
 	}
 
 	if(rootkey)

--- a/src/Remote/reg_set/entry.c
+++ b/src/Remote/reg_set/entry.c
@@ -135,6 +135,7 @@ VOID go(
 	internal_printf("SUCCESS.\n");
 
 go_end:
+	if(type == REG_QWORD){intFree((void*)data);}
 	printoutput(TRUE);
 	
 	bofstop();


### PR DESCRIPTION
Disclosure: I used AI to identify and help me fix this bug. I understand what the code does and have confirmed the fix is correct and compiles.

The first bug is that it frees the RootKey instead of RemoteKey in the first if of the end block. That would zero out and make the next if invalid. Fixed by nulling out RemoteKey instead, which was probably the intention here.

The second issue is just to free the data, but only if it is a QWORD (see line 107). To make this more resilient to track this could be assigned to a dedicated variable, but I didn't feel like introducing that complexity.