### PR TITLE
Update Remote.cna

### DIFF
--- a/Remote/Remote.cna
+++ b/Remote/Remote.cna
@@ -2098,7 +2098,7 @@ alias global_unprotect {
 
 beacon_command_register(
     "global_unprotect",
-    "Attempts to find, decrypt, and download Global Protect VPN profiles and HIP settings"
+    "Attempts to find, decrypt, and download Global Protect VPN profiles and HIP settings",
     "Usage: global_unprotect
     
     There are no arguments to this command"


### PR DESCRIPTION
This commit fixes a small syntax issue for `global_unprotect`. Namely before, the help menu showed a messed up version:

<img width="663" height="123" alt="image" src="https://github.com/user-attachments/assets/dfc7d29c-e9d2-4d58-bb96-a088030b6db3" />

Which this commit fixes:

<img width="1070" height="80" alt="image" src="https://github.com/user-attachments/assets/660910f5-bee5-4e01-ac42-fbd8f8226a1b" />
